### PR TITLE
Provide the production host by default.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: go
 go:
 - "1.10.x"
 env:
-  - FM_HOST=ye2v8tt0o2.execute-api.eu-west-1.amazonaws.com FM_TENANT=711ef17b-1945-40f5-a048-30af1ec94566
+  - FM_TENANT=711ef17b-1945-40f5-a048-30af1ec94566
 
 install:
 # This script is used by the Travis build to install a cookie for

--- a/README.md
+++ b/README.md
@@ -73,4 +73,5 @@ In order to run the full suite of acceptance tests, run `make testacc`.
 $ make testacc
 ```
 
-*Note:* Acceptance tests run against the real API and will need both the host (`FM_HOST`) and tenant ID set (`FM_TENANT`).
+*Note:* Acceptance tests run against the real API and will need the tenant ID
+set (`FM_TENANT`).

--- a/fleetmanager/provider.go
+++ b/fleetmanager/provider.go
@@ -10,8 +10,8 @@ func Provider() terraform.ResourceProvider {
 		Schema: map[string]*schema.Schema{
 			"host": {
 				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("FM_HOST", nil),
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("FM_HOST", "api.fleetmanager.extendaretail.com"),
 			},
 			"tenant_id": {
 				Type:        schema.TypeString,

--- a/fleetmanager/provider_test.go
+++ b/fleetmanager/provider_test.go
@@ -25,10 +25,6 @@ func TestProvider(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	if v := os.Getenv("FM_HOST"); v == "" {
-		t.Fatal("FM_HOST must be set for acceptance tests")
-	}
-
 	if v := os.Getenv("FM_TENANT"); v == "" {
 		t.Fatal("FM_TENANT must be set for acceptance tests")
 	}


### PR DESCRIPTION
This allows overriding the host using the `FM_HOST` environment variable
still, but now won't be required by default.